### PR TITLE
Extended configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,18 @@ Include the requirejs script before testr.js, and be sure to have a valid `data-
 
 ```javascript
 testr.config({
-	autoLoad: true,
+	autoLoad: 'all',
+	specUrl: 'spec',
+	stubUrl: 'stub',
 	whitelist: ['path/to/allowed/actual', 'underscore', 'backbone']
 });
 ```
 
-**autoLoad**: boolean to allow loading of associated `spec` and `stub` files. *Default: false*
+**autoLoad**: boolean or string to allow loading of associated `spec` and `stub` files. Allowed values are true, false, 'spec', 'stub', 'all'. The 'all' value is the same as true. *Default: false*
+
+**specUrl**: path relative to your spec runner where spec files should be auto loaded from. *Default: spec*
+
+**stubUrl**: path relative to your spec runner where stub files should be auto loaded from. *Default: stub*
 
 **whitelist**: an array of paths that are allowed as actual dependencies. All other modules must be stubbed. *Default: off*
 

--- a/testr.js
+++ b/testr.js
@@ -14,7 +14,9 @@ var testr, define;
 		moduleMap = {},
 		pluginPaths = {},
 		config = {
-			autoLoad: false
+			autoLoad: false,
+			specUrl: 'spec',
+			stubUrl: 'stub'
 		};
 
 	// type detection
@@ -142,17 +144,27 @@ var testr, define;
 				require: contextReq
 			};
 
-			if (module.uri.indexOf('./stub') === 0) {
+			if (module.uri.indexOf('./'+config.stubUrl) === 0) {
 				// stub has been saved to module map, no further processing needed
 				return;
 			}
 
 			// auto load associated files
 			if (config.autoLoad) {
+				var autoDeps = [];
+				var loadAll = typeof config.autoLoad === 'boolean' || config.autoLoad === 'all';
+
+				if (loadAll || config.autoLoad === "stub") {
+					autoDeps.push(config.stubUrl + '/' + module.id + '.stub')
+				}
+				if (loadAll || config.autoLoad === "spec") {
+					autoDeps.push(config.specUrl + '/' + module.id + '.spec')
+				}
+
 				require({
 					context: module.id,
 					baseUrl: '.',
-					deps: ['stub/' + module.id + '.stub', 'spec/' + module.id + '.spec']
+					deps: autoDeps
 				});
 			}
 			
@@ -190,7 +202,7 @@ var testr, define;
 			};
 
 		// get external stub
-		externalStub = !subject && useExternal && moduleMap['stub/' + moduleName + '.stub'];
+		externalStub = !subject && useExternal && moduleMap[config.stubUrl + '/' + moduleName + '.stub'];
 
 		// throw error if module must be stubbed
 		if (mustBeStubbed && !subject && !externalStub) {


### PR DESCRIPTION
The autoLoad config option now accepts 'spec', 'stub', and 'all' as well as the original true and false values.  This means you can auto load specs even if you don't want to use external stubs.

I've also added two new configuration options 'specUrl' and 'stubUrl' so that you can customize the location where you store your specs and stubs.
